### PR TITLE
Permission Denied Error Fix

### DIFF
--- a/docs/ubuntu-install.md
+++ b/docs/ubuntu-install.md
@@ -68,6 +68,8 @@ Run this command to download the latest version of Docker Compose:
 
 ```
 curl -L "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+
+chmod +x /usr/local/bin/docker-compose
 ```
 
 ## Step 3: Clone MicroKube


### PR DESCRIPTION
Due to permission errors, docker-compose was not allowed to run while trying to run command "rake service:all" command for starting up the microkube.

Adding chmod +x to the directory fixes the error.