### PR TITLE
Expose port 3000 in vendor yaml template

### DIFF
--- a/templates/compose/vendor.yaml.erb
+++ b/templates/compose/vendor.yaml.erb
@@ -13,6 +13,8 @@ services:
         cd /home/node
         yarn
         yarn start
+    expose:
+      - '3000'
     labels:
       traefik.enable: true
       traefik.frontend.rule: "PathPrefix:/;Host:<%= @config['app']['subdomain'] %>.<%= @config['app']['domain'] %>"


### PR DESCRIPTION
When spinning up the vendor frontend container using docker-compose
no port was mapped. This caused a 'Bad Gateway' error when attempting
to access the UI.