### PR TITLE
Correctly map env.js for vendor docker-compose yaml

### DIFF
--- a/templates/compose/vendor.yaml.erb
+++ b/templates/compose/vendor.yaml.erb
@@ -6,6 +6,7 @@ services:
     user: "${UID}:${GID}"
     volumes:
       - ../vendor/frontend:/home/node
+      - ../config/frontend/env.js:/home/node/public/env.js
     command:
       - sh
       - -c


### PR DESCRIPTION
For deploying non-local microkube environment with vendor frontend. API URL
will default to www.app.local if the volume mapping is not created in the docker compose file.